### PR TITLE
Update linter-ruby to support --one and remove deprecation notices.

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -1,8 +1,10 @@
 path = require 'path'
 
 module.exports =
-  configDefaults:
-    rubyExecutablePath: null
+  config:
+    rubyExecutablePath:
+      default: ''
+      type: 'string'
 
   activate: ->
     console.log 'activate linter-ruby'

--- a/lib/linter-ruby.coffee
+++ b/lib/linter-ruby.coffee
@@ -23,10 +23,10 @@ class LinterRuby extends Linter
   constructor: (editor)->
     super(editor)
 
-    atom.config.observe 'linter-ruby.rubyExecutablePath', =>
+    @rubyLinter = atom.config.observe 'linter-ruby.rubyExecutablePath', =>
       @executablePath = atom.config.get 'linter-ruby.rubyExecutablePath'
 
   destroy: ->
-    atom.config.unobserve 'linter-ruby.rubyExecutablePath'
+    @rubyLinter.dispose
 
 module.exports = LinterRuby

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "repository": "https://github.com/AtomLinter/linter-ruby",
   "license": "MIT",
   "engines": {
-    "atom": ">0.50.0"
+    "atom": ">0.180.0"
   },
   "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "linter-ruby",
   "linter-package": true,
-  "activationEvents": [],
+  "activationCommands": [],
   "main": "./lib/init",
   "version": "0.1.4",
   "description": "Lint Ruby on the fly, using ruby -wc",


### PR DESCRIPTION
* Fix #12, use activationCommands.	027e097
* Update minimum Atom version.	af17d88
* Fix #14, #9, #8 - Use @rubyLinter.dispose. Also fix #10.	41d3434
* Use new config style.