### PR TITLE
Move to a broader regex

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -46,15 +46,15 @@ export default {
           const toReturn = [];
           output.split(/\r?\n/).forEach(function (line) {
             const matches = regex.exec(line);
-            if (matches !== null) {
-              const msg = {
-                range: helpers.rangeFromLineNumber(activeEditor, Number.parseInt(matches[1])),
-                type: "Error",
-                text: matches[2],
-                filePath: file
-              };
-              toReturn.push(msg);
+            if (matches === null) {
+              return;
             }
+            toReturn.push({
+              range: helpers.rangeFromLineNumber(activeEditor, Number.parseInt(matches[1])),
+              type: "Error",
+              text: matches[2],
+              filePath: file
+            });
           });
           return toReturn;
         });

--- a/lib/main.js
+++ b/lib/main.js
@@ -19,7 +19,7 @@ export default {
     //  after a base linter package is integrated into Atom, in the comming
     //  months.
     // TODO: Remove when Linter Base is integrated into Atom.
-    if(!atom.packages.getLoadedPackages("linter")) {
+    if (!atom.packages.getLoadedPackages("linter")) {
       atom.notifications.addError(
         "Linter package not found.",
         {
@@ -32,7 +32,7 @@ export default {
   provideLinter: () => {
     const helpers = require("atom-linter");
     const path = require("path");
-    const regex = "(?<file>.+):(?<line>\\d+):\\s*(?<type>[\\w\\s\\-]+)[:,]?\\s*(?<message>.+)";
+    const regex = /.+:(\d+):\s*(.+)/;
     return {
       grammarScopes: ["source.ruby", "source.ruby.rails", "source.ruby.rspec"],
       scope: "file",
@@ -42,9 +42,22 @@ export default {
         const file = activeEditor.getPath();
         const cwd = path.dirname(file);
         const args = ["-wc", file];
-        return helpers.exec(command, args, {stream: "stderr", cwd: cwd}).then(output =>
-          helpers.parse(output, regex)
-        );
+        return helpers.exec(command, args, {stream: "stderr", cwd: cwd}).then(output => {
+          const toReturn = [];
+          output.split(/\r?\n/).forEach(function (line) {
+            const matches = regex.exec(line);
+            if (matches !== null) {
+              const msg = {
+                range: helpers.rangeFromLineNumber(activeEditor, Number.parseInt(matches[1])),
+                type: "Error",
+                text: matches[2],
+                filePath: file
+              };
+              toReturn.push(msg);
+            }
+          });
+          return toReturn;
+        });
       }
     };
   }


### PR DESCRIPTION
Also generate the messages in the linter to fix several issues such as the file path being incorrect on Windows. Since ruby only gives a line number for errors provide a range that covers the entire line.

Should fix https://github.com/atom-community/linter/issues/822 and make the errors show on the file instead of the "project" on Windows.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-ruby/28)
<!-- Reviewable:end -->
