### PR TITLE
Ignore extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can configure linter-ruby by editing ~/.atom/config.cson (choose Open Your C
 ```
 'linter-ruby':
   'rubyExecutablePath': null #ruby path. run 'which ruby' to find the path.
-  'ignoredExtensions': 'erb,md' #ignored extensions, ERB and markdown files by default.
+  'ignoredExtensions': 'erb, md' #ignored extensions, ERB and markdown files by default.
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ You can configure linter-ruby by editing ~/.atom/config.cson (choose Open Your C
 ```
 'linter-ruby':
   'rubyExecutablePath': null #ruby path. run 'which ruby' to find the path.
+  'ignoredExtensions': 'erb,md' #ignored extensions, ERB and markdown files by default.
 ```
 
 ## Contributing

--- a/lib/main.js
+++ b/lib/main.js
@@ -47,7 +47,7 @@ export default {
         var ignore = false;
 
         ignored.split(",").forEach(function (extension) {
-          if (filePath.split('.').pop() === extension) {
+          if (filePath.split(".").pop() === extension.trim()) {
             ignore = true;
           };
         });

--- a/lib/main.js
+++ b/lib/main.js
@@ -52,26 +52,24 @@ export default {
           };
         });
 
-        if (ignore) {
-          return;
-        } else {
-          return helpers.exec(command, ['-wc'], {stdin: activeEditor.getText(), stream: 'stderr'}).then(output => {
-            var toReturn = [];
-            output.split(/\r?\n/).forEach(function (line) {
-              const matches = regex.exec(line);
-              if (matches === null) {
-                return;
-              }
-              toReturn.push({
-                range: helpers.rangeFromLineNumber(activeEditor, Number.parseInt((matches[1] - 1))),
-                type: matches[2],
-                text: matches[3],
-                filePath: filePath
-              });
+        if (ignore) return [];
+
+        return helpers.exec(command, ['-wc'], {stdin: activeEditor.getText(), stream: 'stderr'}).then(output => {
+          var toReturn = [];
+          output.split(/\r?\n/).forEach(function (line) {
+            const matches = regex.exec(line);
+            if (matches === null) {
+              return;
+            }
+            toReturn.push({
+              range: helpers.rangeFromLineNumber(activeEditor, Number.parseInt((matches[1] - 1))),
+              type: matches[2],
+              text: matches[3],
+              filePath: filePath
             });
-            return toReturn;
           });
-        }
+          return toReturn;
+        });
       }
     };
   }

--- a/lib/main.js
+++ b/lib/main.js
@@ -7,8 +7,11 @@ export default {
       default: "ruby"
     },
     ignoredExtensions: {
-      type: "string",
-      default: "erb,md"
+      type: 'array',
+      default: ['erb', 'md'],
+      items: {
+        type: 'string'
+      }
     }
   },
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -52,7 +52,7 @@ export default {
 
         for (let extension of ignored) {
           if (fileExtension === extension) return [];
-        };
+        }
 
         return helpers.exec(command, ['-wc'], {stdin: activeEditor.getText(), stream: 'stderr'}).then(output => {
           var toReturn = [];

--- a/lib/main.js
+++ b/lib/main.js
@@ -5,6 +5,10 @@ export default {
     rubyExecutablePath: {
       type: "string",
       default: "ruby"
+    },
+    ignoredExtensions: {
+      type: "string",
+      default: "erb,md"
     }
   },
 
@@ -38,23 +42,36 @@ export default {
       lintOnFly: true,
       lint: (activeEditor) => {
         const command = atom.config.get("linter-ruby.rubyExecutablePath");
+        const ignored = atom.config.get("linter-ruby.ignoredExtensions");
         const filePath = activeEditor.getPath();
-        return helpers.exec(command, ['-wc'], {stdin: activeEditor.getText(), stream: 'stderr'}).then(output => {
-          var toReturn = [];
-          output.split(/\r?\n/).forEach(function (line) {
-            const matches = regex.exec(line);
-            if (matches === null) {
-              return;
-            }
-            toReturn.push({
-              range: helpers.rangeFromLineNumber(activeEditor, Number.parseInt((matches[1] - 1))),
-              type: matches[2],
-              text: matches[3],
-              filePath: filePath
-            });
-          });
-          return toReturn;
+        var ignore = false;
+
+        ignored.split(",").forEach(function (extension) {
+          if (filePath.split('.').pop() === extension) {
+            ignore = true;
+          };
         });
+
+        if (ignore) {
+          return;
+        } else {
+          return helpers.exec(command, ['-wc'], {stdin: activeEditor.getText(), stream: 'stderr'}).then(output => {
+            var toReturn = [];
+            output.split(/\r?\n/).forEach(function (line) {
+              const matches = regex.exec(line);
+              if (matches === null) {
+                return;
+              }
+              toReturn.push({
+                range: helpers.rangeFromLineNumber(activeEditor, Number.parseInt((matches[1] - 1))),
+                type: matches[2],
+                text: matches[3],
+                filePath: filePath
+              });
+            });
+            return toReturn;
+          });
+        }
       }
     };
   }

--- a/lib/main.js
+++ b/lib/main.js
@@ -51,7 +51,7 @@ export default {
         const fileExtension = Path.extname(filePath).substr(1);
 
         for (let extension of ignored) {
-          if (fileExtension === extension.trim()) return [];
+          if (fileExtension === extension) return [];
         };
 
         return helpers.exec(command, ['-wc'], {stdin: activeEditor.getText(), stream: 'stderr'}).then(output => {

--- a/lib/main.js
+++ b/lib/main.js
@@ -50,13 +50,9 @@ export default {
         const filePath = activeEditor.getPath();
         const fileExtension = Path.extname(filePath).substr(1);
 
-        ignored.split(",").forEach(function (extension) {
-          if (filePath.split(".").pop() === extension.trim()) {
-            ignore = true;
-          };
-        });
-
-        if (ignore) return [];
+        for (let extension of ignored) {
+          if (fileExtension === extension.trim()) return [];
+        };
 
         return helpers.exec(command, ['-wc'], {stdin: activeEditor.getText(), stream: 'stderr'}).then(output => {
           var toReturn = [];

--- a/lib/main.js
+++ b/lib/main.js
@@ -38,6 +38,7 @@ export default {
 
   provideLinter: () => {
     const helpers = require("atom-linter");
+    const Path = require("path");
     const regex = /.+:(\d+):\s*(.+?):\s(.+)/;
     return {
       grammarScopes: ["source.ruby", "source.ruby.rails", "source.ruby.rspec"],
@@ -47,7 +48,7 @@ export default {
         const command = atom.config.get("linter-ruby.rubyExecutablePath");
         const ignored = atom.config.get("linter-ruby.ignoredExtensions");
         const filePath = activeEditor.getPath();
-        var ignore = false;
+        const fileExtension = Path.extname(filePath).substr(1);
 
         ignored.split(",").forEach(function (extension) {
           if (filePath.split(".").pop() === extension.trim()) {


### PR DESCRIPTION
The linter-erb issue AtomLinter/linter-erb#9 is not resolved yet (linter-erb isn’t updated to use the new linter API) and I don’t how to fix it, this is my best alternative. I was also getting linter errors on markdown files so I included it’s extension as a default as well. I thinks those files should be excluded. Please let me know if this is acceptable. Thanks!

Closes #26