### PR TITLE
Convert to independant package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,8 @@ linter-ruby
 This linter plugin for [Linter](https://github.com/AtomLinter/Linter) provides an interface to Ruby's builtin syntax analysis. It will be used with files that have the `Ruby` syntax.
 
 ## Installation
-Linter package must be installed in order to use this plugin. If Linter is not installed, please follow the instructions [here](https://github.com/AtomLinter/Linter).
-
-### Plugin installation
-```
-$ apm install linter-ruby
-```
+On first activation the plugin will install all dependencies automatically, you no longer have to worry about installing Linter.
+Just install this package and you'll be good to go.
 
 ## Settings
 You can configure linter-ruby by editing ~/.atom/config.cson (choose Open Your Config in Atom menu):

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This linter plugin for [Linter](https://github.com/AtomLinter/Linter) provides a
 
 ## Installation
 On first activation the plugin will install all dependencies automatically, you no longer have to worry about installing Linter.
+
 Just install this package and you'll be good to go.
 
 ## Settings

--- a/lib/main.js
+++ b/lib/main.js
@@ -16,24 +16,9 @@ export default {
   },
 
   activate: () => {
-    // Because all of the grammars this linter supports are
-    //  built into the editor we do not need to throw errors when
-    //  any one of the grammmars isn't installed. If a user has the grammar
-    //  disabled that is a choice they have made.
-
-    // Show the user an error if they do not have an appropriate linter base
-    //  package installed from Atom Package Manager. This will not be an issues
-    //  after a base linter package is integrated into Atom, in the comming
-    //  months.
-    // TODO: Remove when Linter Base is integrated into Atom.
-    if (!atom.packages.getLoadedPackages("linter")) {
-      atom.notifications.addError(
-        "Linter package not found.",
-        {
-          detail: "Please install the `linter` package in your Settings view."
-        }
-      );
-    }
+    // We are now using steelbrain's package dependency package to install our
+    //  dependencies.
+    require("atom-package-deps").install("linter-ruby");
   },
 
   provideLinter: () => {

--- a/package.json
+++ b/package.json
@@ -16,11 +16,15 @@
     }
   },
   "dependencies": {
-    "atom-linter": "^3.0.0"
+    "atom-linter": "^3.0.0",
+    "atom-package-deps": "^2.0.0"
   },
   "devDependencies": {
     "eslint": "latest"
   },
+  "package-deps": [
+    "linter"
+  ],
   "eslintConfig": {
     "env": {
       "es6": true,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "atom-linter": "^3.0.0",
-    "atom-package-deps": "^2.0.0"
+    "atom-package-deps": "^2.0.1"
   },
   "devDependencies": {
     "eslint": "latest"


### PR DESCRIPTION
We are still using linter to show issues, but now the user will not have to follow a lengthy installation process.

This is possible with @steelbrain's [package-deps](https://github.com/steelbrain/package-deps) package.