### PR TITLE
Add linter name

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -26,6 +26,7 @@ export default {
     const Path = require("path");
     const regex = /.+:(\d+):\s*(.+?):\s(.+)/;
     return {
+      name: "Ruby",
       grammarScopes: ["source.ruby", "source.ruby.rails", "source.ruby.rspec"],
       scope: "file",
       lintOnFly: true,


### PR DESCRIPTION
Specifies the linter name, allowing the `linter` package to display it if the user chooses to.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-ruby/45)
<!-- Reviewable:end -->
