### PR TITLE
set utf8 encoding for check

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -40,7 +40,7 @@ export default {
           if (fileExtension === extension) return [];
         }
 
-        return helpers.exec(command, ['-wc'], {stdin: activeEditor.getText(), stream: 'stderr'}).then(output => {
+        return helpers.exec(command, ['-wc', '-Ku'], {stdin: activeEditor.getText(), stream: 'stderr'}).then(output => {
           var toReturn = [];
           output.split(/\r?\n/).forEach(function (line) {
             const matches = regex.exec(line);


### PR DESCRIPTION
linter-ruby throws error for non-ascii characters. add command-line arguments to set utf-8 encoding