### PR TITLE
Improve Atom startup time

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "engines": {
     "atom": ">0.180.0"
   },
+  "activationHooks": ["language-ruby:grammar-used"],
   "providedServices": {
     "linter": {
       "versions": {


### PR DESCRIPTION
Before this change, activation was done on Atom startup, whether or not
you actually had any Ruby files open.

With this change in place, we postpone activation until the Atom
Ruby grammar's first use.

This improves startup time of my Atom by about 20ms, thus fixing one of
the top startup time offenders according to TimeCop.

For some frame of reference, I have 87 packages installed, and Timecop
lists all packages with startup times above 5ms.