### PR TITLE
Add language-ruby-on-rails to activation list

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
   "engines": {
     "atom": ">0.180.0"
   },
-  "activationHooks": ["language-ruby:grammar-used"],
+  "activationHooks": [
+    "language-ruby:grammar-used",
+    "language-ruby-on-rails:grammar-used"
+  ],
   "providedServices": {
     "linter": {
       "versions": {


### PR DESCRIPTION
Atom seems to like using `language-ruby-on-rails` over `language-ruby` for plain Ruby files, add it to the list of languages that activate this package.

Fixes #96.