### PR TITLE
Cleanup and bugfixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ If you would like to contribute enhancements or fixes, please do the following:
 Please note that modifications should follow these coding guidelines:
 
 -   Indent is 2 spaces.
--   Code should pass coffeelint linter.
+-   Code should pass ESLint linter (`npm run lint`).
 -   Vertical whitespace helps readability, don’t be afraid to use it.
 
 Thank you for helping out!

--- a/lib/main.js
+++ b/lib/main.js
@@ -2,13 +2,25 @@
 
 import * as helpers from 'atom-linter';
 import { extname } from 'path';
+// eslint-disable-next-line import/extensions, import/no-extraneous-dependencies
+import { CompositeDisposable } from 'atom';
 
 export default {
-  activate: () => {
+  activate() {
     require('atom-package-deps').install('linter-ruby');
+
+    this.subscriptions = new CompositeDisposable();
+    this.subscriptions.add(atom.config.observe('linter-ruby.rubyExecutablePath',
+      (value) => { this.executablePath = value; }));
+    this.subscriptions.add(atom.config.observe('linter-ruby.ignoredExtensions',
+      (value) => { this.ignoredExtensions = value; }));
   },
 
-  provideLinter: () => {
+  deactivate() {
+    this.subscriptions.dispose();
+  },
+
+  provideLinter() {
     const regex = /.+:(\d+):\s*(.+?)[,:]\s(.+)/;
     return {
       name: 'Ruby',
@@ -16,12 +28,10 @@ export default {
       scope: 'file',
       lintOnFly: true,
       lint: async (activeEditor) => {
-        const command = atom.config.get('linter-ruby.rubyExecutablePath');
-        const ignored = atom.config.get('linter-ruby.ignoredExtensions');
         const filePath = activeEditor.getPath();
         const fileExtension = extname(filePath).substr(1);
 
-        if (ignored.includes(fileExtension)) {
+        if (this.ignoredExtensions.includes(fileExtension)) {
           return [];
         }
 
@@ -30,7 +40,7 @@ export default {
           stdin: activeEditor.getText(),
           stream: 'stderr',
         };
-        const output = await helpers.exec(command, execArgs, execOpts);
+        const output = await helpers.exec(this.executablePath, execArgs, execOpts);
         const toReturn = [];
         output.split(/\r?\n/).forEach((line) => {
           const matches = regex.exec(line);

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,20 +1,6 @@
 'use babel';
 
 export default {
-  config: {
-    rubyExecutablePath: {
-      type: 'string',
-      default: 'ruby',
-    },
-    ignoredExtensions: {
-      type: 'array',
-      default: ['erb', 'md'],
-      items: {
-        type: 'string',
-      },
-    },
-  },
-
   activate: () => {
     // We are now using steelbrain's package dependency package to install our
     //  dependencies.

--- a/lib/main.js
+++ b/lib/main.js
@@ -29,6 +29,7 @@ export default {
       lintOnFly: true,
       lint: async (textEditor) => {
         const filePath = textEditor.getPath();
+        const fileText = textEditor.getText();
         const fileExtension = extname(filePath).substr(1);
 
         if (this.ignoredExtensions.includes(fileExtension)) {
@@ -37,10 +38,14 @@ export default {
 
         const execArgs = ['-wc', '-E utf-8'];
         const execOpts = {
-          stdin: textEditor.getText(),
+          stdin: fileText,
           stream: 'stderr',
         };
         const output = await helpers.exec(this.executablePath, execArgs, execOpts);
+        if (textEditor.getText() !== fileText) {
+          // File contents have changed, just tell Linter not to update messages
+          return null;
+        }
         const toReturn = [];
         let match = regex.exec(output);
         while (match !== null) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -15,7 +15,7 @@ export default {
       grammarScopes: ['source.ruby', 'source.ruby.rails', 'source.ruby.rspec'],
       scope: 'file',
       lintOnFly: true,
-      lint: (activeEditor) => {
+      lint: async (activeEditor) => {
         const command = atom.config.get('linter-ruby.rubyExecutablePath');
         const ignored = atom.config.get('linter-ruby.ignoredExtensions');
         const filePath = activeEditor.getPath();
@@ -25,23 +25,27 @@ export default {
           return [];
         }
 
-        return helpers.exec(command, ['-wc', '-E utf-8'], { stdin: activeEditor.getText(), stream: 'stderr' }).then((output) => {
-          const toReturn = [];
-          output.split(/\r?\n/).forEach((line) => {
-            const matches = regex.exec(line);
-            if (matches === null) {
-              return;
-            }
-            const msgLine = Number.parseInt(matches[1] - 1, 10);
-            toReturn.push({
-              range: helpers.rangeFromLineNumber(activeEditor, msgLine),
-              type: matches[2],
-              text: matches[3],
-              filePath,
-            });
+        const execArgs = ['-wc', '-E utf-8'];
+        const execOpts = {
+          stdin: activeEditor.getText(),
+          stream: 'stderr',
+        };
+        const output = await helpers.exec(command, execArgs, execOpts);
+        const toReturn = [];
+        output.split(/\r?\n/).forEach((line) => {
+          const matches = regex.exec(line);
+          if (matches === null) {
+            return;
+          }
+          const msgLine = Number.parseInt(matches[1] - 1, 10);
+          toReturn.push({
+            range: helpers.rangeFromLineNumber(activeEditor, msgLine),
+            type: matches[2],
+            text: matches[3],
+            filePath,
           });
-          return toReturn;
         });
+        return toReturn;
       },
     };
   },

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,13 +1,14 @@
 'use babel';
 
+import * as helpers from 'atom-linter';
+import { extname } from 'path';
+
 export default {
   activate: () => {
     require('atom-package-deps').install('linter-ruby');
   },
 
   provideLinter: () => {
-    const helpers = require('atom-linter');
-    const Path = require('path');
     const regex = /.+:(\d+):\s*(.+?)[,:]\s(.+)/;
     return {
       name: 'Ruby',
@@ -18,7 +19,7 @@ export default {
         const command = atom.config.get('linter-ruby.rubyExecutablePath');
         const ignored = atom.config.get('linter-ruby.ignoredExtensions');
         const filePath = activeEditor.getPath();
-        const fileExtension = Path.extname(filePath).substr(1);
+        const fileExtension = extname(filePath).substr(1);
 
         if (ignored.includes(fileExtension)) {
           return [];

--- a/lib/main.js
+++ b/lib/main.js
@@ -27,8 +27,8 @@ export default {
       grammarScopes: ['source.ruby', 'source.ruby.rails', 'source.ruby.rspec'],
       scope: 'file',
       lintOnFly: true,
-      lint: async (activeEditor) => {
-        const filePath = activeEditor.getPath();
+      lint: async (textEditor) => {
+        const filePath = textEditor.getPath();
         const fileExtension = extname(filePath).substr(1);
 
         if (this.ignoredExtensions.includes(fileExtension)) {
@@ -37,7 +37,7 @@ export default {
 
         const execArgs = ['-wc', '-E utf-8'];
         const execOpts = {
-          stdin: activeEditor.getText(),
+          stdin: textEditor.getText(),
           stream: 'stderr',
         };
         const output = await helpers.exec(this.executablePath, execArgs, execOpts);
@@ -49,7 +49,7 @@ export default {
           }
           const msgLine = Number.parseInt(matches[1] - 1, 10);
           toReturn.push({
-            range: helpers.rangeFromLineNumber(activeEditor, msgLine),
+            range: helpers.rangeFromLineNumber(textEditor, msgLine),
             type: matches[2],
             text: matches[3],
             filePath,

--- a/lib/main.js
+++ b/lib/main.js
@@ -36,7 +36,7 @@ export default {
           return [];
         }
 
-        const execArgs = ['-wc', '-E utf-8'];
+        const execArgs = ['-wc', '-Eutf-8'];
         const execOpts = {
           stdin: fileText,
           stream: 'stderr',

--- a/lib/main.js
+++ b/lib/main.js
@@ -2,9 +2,7 @@
 
 export default {
   activate: () => {
-    // We are now using steelbrain's package dependency package to install our
-    //  dependencies.
-    require('atom-package-deps').install();
+    require('atom-package-deps').install('linter-ruby');
   },
 
   provideLinter: () => {

--- a/lib/main.js
+++ b/lib/main.js
@@ -40,6 +40,7 @@ export default {
         const execOpts = {
           stdin: fileText,
           stream: 'stderr',
+          allowEmptyStderr: true,
         };
         const output = await helpers.exec(this.executablePath, execArgs, execOpts);
         if (textEditor.getText() !== fileText) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -21,7 +21,7 @@ export default {
   },
 
   provideLinter() {
-    const regex = /.+:(\d+):\s*(.+?)[,:]\s(.+)/;
+    const regex = /.+:(\d+):\s*(.+?)[,:]\s(.+)/g;
     return {
       name: 'Ruby',
       grammarScopes: ['source.ruby', 'source.ruby.rails', 'source.ruby.rspec'],
@@ -42,19 +42,17 @@ export default {
         };
         const output = await helpers.exec(this.executablePath, execArgs, execOpts);
         const toReturn = [];
-        output.split(/\r?\n/).forEach((line) => {
-          const matches = regex.exec(line);
-          if (matches === null) {
-            return;
-          }
-          const msgLine = Number.parseInt(matches[1] - 1, 10);
+        let match = regex.exec(output);
+        while (match !== null) {
+          const msgLine = Number.parseInt(match[1] - 1, 10);
           toReturn.push({
             range: helpers.rangeFromLineNumber(textEditor, msgLine),
-            type: matches[2],
-            text: matches[3],
+            type: match[2],
+            text: match[3],
             filePath,
           });
-        });
+          match = regex.exec(output);
+        }
         return toReturn;
       },
     };

--- a/package.json
+++ b/package.json
@@ -6,12 +6,25 @@
   "repository": "https://github.com/AtomLinter/linter-ruby",
   "license": "MIT",
   "engines": {
-    "atom": ">0.180.0"
+    "atom": ">=1.4.0 <2.0.0"
   },
   "activationHooks": [
     "language-ruby:grammar-used",
     "language-ruby-on-rails:grammar-used"
   ],
+  "configSchema": {
+    "rubyExecutablePath": {
+      "type": "string",
+      "default": "ruby"
+    },
+    "ignoredExtensions": {
+      "type": "array",
+      "default": ["erb", "md"],
+      "items": {
+        "type": "string"
+      }
+    }
+  },
   "providedServices": {
     "linter": {
       "versions": {


### PR DESCRIPTION
Many small upgrades and cleanup to the code, generally bringing it in line with other current linter providers including:

* Utilizing ES2017 features
* Move to a `configSchema`
* Observing settings instead of `get`ing them on every lint call

Also fixes a few bugs:
* Guard against a potential race condition where the file is edited _after_ a lint was triggered, but before the results are returned, leading to the possibility of the positions returned being no longer correct, thus triggering a false positive on the invalid point check.
* Fix the encoding specification, for some reason some platforms don't like `-E utf-8`, treating the encoding from that as ` utf-8` (with a space on the front. As the documentation doesn't show a space before the option, simply remove it to make this work on all platforms.
* Allow no output: On files with no issues there is no output, which would cause an error as of the upgrade to `atom-linter@8`.