### PR TITLE
Fix styling of syntax errors

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -51,9 +51,10 @@ export default {
         let match = regex.exec(output);
         while (match !== null) {
           const msgLine = Number.parseInt(match[1] - 1, 10);
+          const type = match[2] === 'warning' ? 'Warning' : 'Error';
           toReturn.push({
             range: helpers.rangeFromLineNumber(textEditor, msgLine),
-            type: match[2],
+            type,
             text: match[3],
             filePath,
           });

--- a/spec/linter-ruby-spec.js
+++ b/spec/linter-ruby-spec.js
@@ -43,13 +43,13 @@ describe('The Ruby provider for Linter', () => {
         lint(editor).then((messages) => {
           expect(messages.length).toBe(2);
 
-          expect(messages[0].type).toBe('warning');
+          expect(messages[0].type).toBe('Warning');
           expect(messages[0].html).not.toBeDefined();
           expect(messages[0].text).toBe('assigned but unused variable - payload');
           expect(messages[0].filePath).toBe(badPath);
           expect(messages[0].range).toEqual([[1, 2], [1, 13]]);
 
-          expect(messages[1].type).toBe('syntax error');
+          expect(messages[1].type).toBe('Error');
           expect(messages[1].html).not.toBeDefined();
           expect(messages[1].text).toBe('unexpected keyword_end, expecting end-of-input');
           expect(messages[1].filePath).toBe(badPath);


### PR DESCRIPTION
Since we were previously specifying the message type to be `syntax error`, Linter didn't have a pre-defined style for the messages. Move to just using `Error`, which Linter will style for us.

Fixes #94.