### PR TITLE
Changing validation encoding

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -36,7 +36,7 @@ export default {
           return [];
         }
 
-        const execArgs = ['-wc', '-Eutf-8'];
+        const execArgs = ['-wc', 'utf-8'];
         const execOpts = {
           stdin: fileText,
           stream: 'stderr',


### PR DESCRIPTION
Previously I have opened [issue](https://github.com/AtomLinter/linter-ruby/issues/106), where I had a problem using other languages except English. This problem can be fixed by changing the encoding from '-Eutf-8' to 'utf-8' passed as argument.