### PR TITLE
Remove macOS Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,6 @@ matrix:
       rvm: 2.3.1
       env: ATOM_CHANNEL=beta
 
-    - os: osx
-      rvm: 2.3.1
-      env: ATOM_CHANNEL=stable
-
 ### Generic setup follows ###
 script:
   - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh


### PR DESCRIPTION
Travis-CI has become completely unusable for macOS testing, with builds consistently taking over 2 hours to finish queueing.