### PR TITLE
Set the file encoding correctly

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -36,7 +36,7 @@ export default {
           return [];
         }
 
-        const execArgs = ['-wc', '-Eutf-8'];
+        const execArgs = ['-wc', '-E utf-8'];
         const execOpts = {
           stdin: fileText,
           stream: 'stderr',


### PR DESCRIPTION
This fixes end-of-input-errors that occur because of utf-8 characters in method arguments, as described here: https://github.com/AtomLinter/linter-ruby/issues/103#issuecomment-278307680
