### PR TITLE
Change how encoding is specified

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -36,7 +36,13 @@ export default {
           return [];
         }
 
-        const execArgs = ['-wc', '-Eutf-8'];
+        const execArgs = [
+          '-c', // Check syntax only, no execution
+          '-w', // Turns on warnings
+          // Set the encoding to UTF-8
+          '--external-encoding=utf-8',
+          '--internal-encoding=utf-8',
+        ];
         const execOpts = {
           stdin: fileText,
           stream: 'stderr',


### PR DESCRIPTION
Apparently on macOS Ruby has different command line arguments from all the other OS's, thankfully it seems the `--external-encoding` and `--internal-encoding` options are the same, and the `-Eutf-8` (`-E utf-8` on macOS...) that was in use before is equivalent to setting both of those anyway.