### PR TITLE
Guard against pathless TextEditor

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -29,6 +29,10 @@ export default {
       lintOnFly: true,
       lint: async (textEditor) => {
         const filePath = textEditor.getPath();
+        if (!filePath) {
+          // We somehow got called without a file path
+          return null;
+        }
         const fileText = textEditor.getText();
         const fileExtension = extname(filePath).substr(1);
 


### PR DESCRIPTION
Somehow we can get called on a TextEditor that doesn't have a path
associated with it. Guard against this case.

Fixes #119.