### PR TITLE
Fix #103. Add '-Ku' to list of args and prevent problems with utf-8

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -50,6 +50,7 @@ export default {
           // Set the encoding to UTF-8
           '--external-encoding=utf-8',
           '--internal-encoding=utf-8',
+          '-Ku',
         ];
         const execOpts = {
           stdin: fileText,


### PR DESCRIPTION
I noticed that [vscode-ruby](https://github.com/rubyide/vscode-ruby) checks the code with these arguments: `-Wc -Ku`.
It turns out that adding `-Ku` to list of arguments solves problem with utf-8 on macOS (#103).

**man ruby** says
```
-K kcode  Specifies KANJI (Japanese) encoding. The default value for script encodings (__ENCODING__) and external encodings
          (Encoding.default_external) will be the specified one. kcode can be one of

                     e       EUC-JP

                     s       Windows-31J (CP932)

                     u       UTF-8

                     n       ASCII-8BIT (BINARY)
```

And nothing seems broken.